### PR TITLE
Update pyproject.toml to disable strict versioning like other NRLMMD …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
     # # # This source code is protected under the license referenced at
     # # # https://github.com/NRLMMD-GEOIPS.
 
+| ⚠️ **Warning** |
+| -------------- |
+| This package is an early release and should be expected to change in the future. We don’t expect the functionality to change in significant ways. We intend to improve the installation process, consolidate packages and, potentially, convert Fortran routines to Python to avoid complexity in installation. |
+
 GeoColor GeoIPS Plugin
 ======================
 

--- a/docs/source/releases/latest/8-add-disclaimer-to-readme.yaml
+++ b/docs/source/releases/latest/8-add-disclaimer-to-readme.yaml
@@ -14,5 +14,5 @@ documentation:
     number: 8
     repo_url: 'https://github.com/NRLMMD-GEOIPS/geocolor'
   date:
-    start: 04032025
-    finish: 04032025
+    start: 2025-04-03
+    finish: 2025-04-03

--- a/docs/source/releases/latest/8-add-disclaimer-to-readme.yaml
+++ b/docs/source/releases/latest/8-add-disclaimer-to-readme.yaml
@@ -1,0 +1,18 @@
+documentation:
+- title: 'Add disclaimer to readme'
+  description: 'Added a disclaimer to the readme to describe the state of this plugin package'
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - 'README.md'
+  related-issue:
+    number: 8
+    repo_url: 'https://github.com/NRLMMD-GEOIPS/geocolor'
+  date:
+    start: 04032025
+    finish: 04032025

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ metadata = false # don't include local-version hash; date doesn't appear by deaf
 style = "pep440" # pep440 is deafult; can rmeove later on; used for : keeping 0.0.8 as the default install until 0.0.9 is out
 #style = "semver"
 #tag-branch = "feature-poetry"
-strict = true
+strict = false
 pattern = "(?x)^((?P<epoch>\\d+)!)?(?P<base>\\d+(\\.\\d+)*)([-._]?((?P<stage>[a-zA-Z]+)[-._]?(?P<revision>\\d+)?))?(\\+(?P<tagged_metadata>.+))?$"
 
 # NOTE: You must CREATE a _version.py file and commit it via git!


### PR DESCRIPTION
The pyproject.toml had strict set to True, which means that it will raise errors when no git history is available. I change it here to allow shallow clones in CI and to be consistent with other GeoIPS repos.